### PR TITLE
Remove obsolete asyncio dependency and update pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-asyncio~=3.4.0
 metno-locationforecast>=1.2
 geopy~=2.4.0
 redis~=5.0.0
 pysolar==0.11
 timezonefinder~=6.5.0
-pytz==2024.1
+pytz==2024.2


### PR DESCRIPTION
- Remove asyncio~=3.4.0 as it's built into Python 3.8+ standard library
- Update pytz from 2024.1 to 2024.2 for latest timezone data