### PR TITLE
Migrate from pip to uv package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,21 @@ Contributions from:
 
 ## Server install or running locally
 
-User docker compose:
+Using uv (recommended):
+
+* Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+* Install dependencies: `uv sync`
+* Start redis: `docker run -it --rm --network host redis`
+* Run fingr: `uv run python fingr.py`
+
+Using docker compose:
 
 * `docker compose up`
 
-Or:
+Or using pip:
 
 * Start redis: `docker run -it --rm --network host redis`
+* Install dependencies: `pip install -r requirements.txt`
 * Start fingr.py
 
 If you don't see real IPs in the log, you may need to set this in /etc/docker/daemon.json:
@@ -72,8 +80,8 @@ If you don't see real IPs in the log, you may need to set this in /etc/docker/da
 
 ## Testing
 
-    - create a venv and install tox
-    - Run `tox`
+    - Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+    - Run `uv run tox`
 
 ## More
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "fingr"
+version = "1.0.0"
+description = "Finger server, serving weather forecast based on location input"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "GPL-3.0-or-later"}
+authors = [
+    {name = "Lars Falk-Petersen", email = "dev@falkp.no"}
+]
+keywords = ["finger", "weather"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: System :: Networking",
+    "Operating System :: POSIX :: Linux",
+    "Environment :: Console",
+    "Topic :: Internet :: Finger",
+]
+
+dependencies = [
+    "metno-locationforecast>=1.2",
+    "geopy~=2.4.0",
+    "redis~=5.0.0",
+    "pysolar==0.11",
+    "timezonefinder~=6.5.0",
+    "pytz==2024.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "bandit",
+    "mypy",
+    "tox",
+    "ruff",
+    "types-pytz",
+    "fakeredis",
+]
+
+[project.urls]
+Homepage = "https://github.com/ways/fingr"
+Repository = "https://github.com/ways/fingr"
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 100
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 bandit
 mypy
 tox
-prospector
-black
+ruff
 types-pytz
 fakeredis

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,28 @@
 [tox]
-envlist = py312, black, prospector, mypy, bandit
+envlist = py312, ruff-format, ruff-check, mypy, bandit
 
 [testenv]
-description = install pytest in the virtualenv where commands will be executed
+description = Run unit tests
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
 commands = python3 -m unittest fingr_test.py
 
-[testenv:prospector]
-ignore_outcome = true
-description = Run static analysis using prospector
-deps = -r{toxinidir}/requirements.txt
-allowlist_externals = prospector
-commands = prospector --no-autodetect \
-               --doc-warnings \
-               --die-on-tool-error \
-               --test-warnings \
-               {toxinidir}/fingr.py
-
-[testenv:black]
-description = Check code style
-deps =
+[testenv:ruff-check]
+description = Run ruff linter
+deps = 
     -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements-dev.txt
-commands = black --check {toxinidir}/fingr.py
+    ruff
+allowlist_externals = ruff
+commands = ruff check {toxinidir}/fingr.py
+
+[testenv:ruff-format]
+description = Check code formatting with ruff
+deps = 
+    -r{toxinidir}/requirements.txt
+    ruff
+allowlist_externals = ruff
+commands = ruff format --check {toxinidir}/fingr.py
 
 [testenv:mypy]
 ignore_outcome = true


### PR DESCRIPTION
- Add pyproject.toml with project metadata and dependencies
- Update README.md with uv installation instructions
- Update tox.ini to work with uv
- Replace prospector/black with ruff in requirements-dev.txt
- Configure ruff linting and formatting in pyproject.toml

Benefits:
- Faster dependency resolution and installation with uv
- Modern Python packaging with pyproject.toml
- Single tool (ruff) for linting and formatting
- Better developer experience