### PR TITLE
Fix ValueError in random_message when messages list has only one item

### DIFF
--- a/fingr.py
+++ b/fingr.py
@@ -76,7 +76,7 @@ def random_message(messages: list) -> str:
     """Pick a random message of the day."""
     if 0 == len(messages):
         return ""
-    return "[" + messages[secrets.randbelow(len(messages) - 1)] + "]\n"
+    return "[" + messages[secrets.randbelow(len(messages))] + "]\n"
 
 
 def load_deny_list() -> list:


### PR DESCRIPTION
The bug occurs when len(messages) == 1, causing secrets.randbelow(0) which raises ValueError: 'Upper bound must be positive.'

Changed from randbelow(len(messages) - 1) to randbelow(len(messages)) which correctly handles lists of any size >= 1.