### PR TITLE
Migrate tox to use uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ indent-style = "space"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+requires =
+    tox>=4
+    tox-uv
 envlist = py, ruff-format, ruff-check, mypy, bandit
 
 [testenv]


### PR DESCRIPTION
- Add tox-uv as requirement in tox configuration
- Configure all test environments to use uv-venv-runner
- This improves dependency resolution speed and consistency
- uv is significantly faster than pip for package installation