### PR TITLE
Fix Docker dependency installation issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,16 @@
 FROM python:3.13-slim AS builder
 
 WORKDIR /app
+
+# Copy only pyproject.toml first to leverage Docker cache
 COPY pyproject.toml .
-RUN pip install --no-cache-dir --target=/app/packages /app
+
+# Create a minimal setup to install dependencies from pyproject.toml
+# We create a dummy package structure so pip can resolve dependencies
+RUN mkdir -p fingr_pkg && \
+    echo "# Dummy" > fingr_pkg/__init__.py && \
+    pip install --no-cache-dir --target=/app/packages . && \
+    rm -rf fingr_pkg
 
 # Runtime stage - distroless
 FROM gcr.io/distroless/python3-debian12:nonroot

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,14 +7,18 @@ FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml /var/fingr/
 WORKDIR /var/fingr/
 
+# Copy all necessary files for installation
+COPY pyproject.toml fingr.py /var/fingr/
+
+# Create venv and install package with dependencies
 RUN python3 -m venv /var/fingr/venv && \
     /var/fingr/venv/bin/pip install --no-cache-dir wheel && \
-    /var/fingr/venv/bin/pip install --no-cache-dir /var/fingr
+    /var/fingr/venv/bin/pip install --no-cache-dir .
 
-COPY fingr.py motd.txt* deny.txt* useragent.txt* /var/fingr/
+# Copy additional runtime files
+COPY motd.txt* deny.txt* useragent.txt* /var/fingr/
 
 RUN useradd fingr && mkdir -p /var/fingr/data && chown -R fingr /var/fingr/data
 USER fingr


### PR DESCRIPTION
- Dockerfile: Create dummy package structure to allow pip to resolve dependencies
- Dockerfile.ubuntu: Copy source files before installing to ensure proper dependency resolution
- Fixes ModuleNotFoundError for async_timeout and other transitive dependencies

The issue was that pip install with --target or in a venv needs the package structure present to properly resolve all transitive dependencies like async_timeout which is required by redis but not explicitly listed in pyproject.toml.