### PR TITLE
Modernize Dockerfile to use uv instead of pip

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Git
+.git
+.gitignore
+.github
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info
+dist/
+build/
+.mypy_cache
+.ruff_cache
+.pytest_cache
+
+# Testing and development
+.tox
+fingr_test.py
+pre_project_tests
+
+# Documentation
+*.md
+!README.md
+LICENSE
+
+# Docker
+Dockerfile.ubuntu
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Environment
+.env
+.venv
+venv/


### PR DESCRIPTION
Improvements:
- Use uv for faster dependency installation
- Enable UV_COMPILE_BYTECODE=1 for precompiled .pyc files (faster startup)
- Simplify installation by using standard site-packages location
- Remove dummy package workaround (uv handles this better)
- Copy fingr.py to builder to avoid installation issues

Optimization:
- Add comprehensive .dockerignore to reduce build context
- Exclude test files, docs, and dev tools from image

Result: Faster builds, smaller context, and faster Python startup.